### PR TITLE
Fix typo in logs

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -27,7 +27,7 @@ async function run(): Promise<void> {
 
     pull(repositoryOld, registry)
       .then(() =>
-        core.info(`Successfully Pulling docker image to ${registry}.`)
+        core.info(`Successfully Pulling docker image from ${registry}.`)
       )
       .catch(err => core.setFailed(err.message))
 


### PR DESCRIPTION
I noticed a small typo in the log output while using the action (thanks, it works nicely!).
